### PR TITLE
Force reload of representations after performing unsafe HTTP requests

### DIFF
--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -30,28 +30,34 @@ class HalClient
         @raw && ! hashish?(@raw)
     end
 
-    # Posts a `Representation` or `String` to this resource.
+    # Posts a `Representation` or `String` to this resource. Causes
+    # this representation to be reloaded the next time it is used.
     #
     # data - a `String` or an object that responds to `#to_hal`
     # options - set of options to pass to `HalClient#post`
     def post(data, options={})
       @hal_client.post(href, data, options)
+      reset
     end
 
-    # Puts a `Representation` or `String` to this resource.
+    # Puts a `Representation` or `String` to this resource. Causes
+    # this representation to be reloaded the next time it is used.
     #
     # data - a `String` or an object that responds to `#to_hal`
     # options - set of options to pass to `HalClient#put`
     def put(data, options={})
       @hal_client.put(href, data, options)
+      reset
     end
 
-    # Patchs a `Representation` or `String` to this resource.
+    # Patchs a `Representation` or `String` to this resource. Causes
+    # this representation to be reloaded the next time it is used.
     #
     # data - a `String` or an object that responds to `#to_hal`
     # options - set of options to pass to `HalClient#patch`
     def patch(data, options={})
       @hal_client.patch(href, data, options)
+      reset
     end
 
     # Returns true if this representation contains the specified
@@ -201,8 +207,20 @@ class HalClient
       Array(linked) + Array(embedded).map(&:href)
     end
 
+    # Returns an Enumerable of the items in this collection resource
+    # if this is an rfc 6573 collection.
+    #
+    # Raises HalClient::NotACollectionError if this is not a
+    # collection resource.
     def as_enum
       Collection.new(self)
+    end
+
+    # Resets this representation such that it will be requested from
+    # the upstream on it's next use.
+    def reset
+      @href = href # make sure we have the href
+      @raw = nil
     end
 
     # Returns a short human readable description of this

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.4.2"
+  VERSION = "3.4.0"
 end

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -24,51 +24,66 @@ HAL
                                        parsed_json: MultiJson.load(raw_repr)) }
 
   describe "#post" do
-    let!(:post_request) {
-      stub_request(:post, repr.href)
-    }
+    let!(:post_request) {stub_request(:post, repr.href) }
+    let!(:reload_request) { stub_request(:get, repr.href).to_return(body: raw_repr) }
 
     before(:each) do
       repr.post("abc")
     end
 
-    specify("makes request") {
+    it("makes request") do
       expect(post_request.with(:body => "abc",
-                                :headers => {'Content-Type' => 'application/hal+json'}))
+                               :headers => {
+                                 'Content-Type' => 'application/hal+json'
+                               })
+            )
         .to have_been_made
-    }
+    end
+
+    it("refetches repr afterwards") do
+      repr.property("prop1")
+      expect(reload_request).to have_been_made
+    end
   end
 
   describe "#put" do
-    let!(:put_request) {
-      stub_request(:put, repr.href)
-    }
+    let!(:put_request) { stub_request(:put, repr.href) }
+    let!(:reload_request) { stub_request(:get, repr.href).to_return(body: raw_repr) }
 
     before(:each) do
       repr.put("abc")
     end
 
-    specify("makes request") {
+    specify("makes request") do
       expect(put_request.with(:body => "abc",
                               :headers => {'Content-Type' => 'application/hal+json'}))
         .to have_been_made
-    }
-  end
+    end
+
+    it("refetches repr afterwards") do
+      repr.property("prop1")
+      expect(reload_request).to have_been_made
+    end
+end
 
   describe "#patch" do
-    let!(:patch_request) {
-      stub_request(:patch, repr.href)
-    }
+    let!(:patch_request) {stub_request(:patch, repr.href)}
+    let!(:reload_request) { stub_request(:get, repr.href).to_return(body: raw_repr) }
 
     before(:each) do
       repr.patch("abc")
     end
 
-    specify("makes request") {
+    specify("makes request") do
       expect(patch_request.with(:body => "abc",
                                 :headers => {'Content-Type' => 'application/hal+json'}))
         .to have_been_made
-    }
+    end
+
+    it("refetches repr afterwards") do
+      repr.property("prop1")
+      expect(reload_request).to have_been_made
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
This prevents it appearing like the resource was not updated on successful put/post/patch requests.
