### PR TITLE
Add ==, eql?, and hash to HalClient::Representation

### DIFF
--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -238,6 +238,24 @@ class HalClient
     end
     alias_method :to_hal, :to_json
 
+    def hash
+      if href
+        href.hash
+      else
+        @raw.hash
+      end
+    end
+
+    def ==(other)
+      super
+      if href
+        href == other.href
+      else
+        @raw == other.raw
+      end
+    end
+    alias :eql? :==
+
     # Internal: Returns parsed json document
     def raw
       if @raw.nil? && @href
@@ -328,6 +346,5 @@ end
     end
 
     def_delegators :links, :namespaces
-
   end
 end

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -247,10 +247,12 @@ class HalClient
     end
 
     def ==(other)
-      if href
+      if href && other.respond_to?(:href)
         href == other.href
-      else
+      elsif other.respond_to?(:raw)
         @raw == other.raw
+      else
+        false
       end
     end
     alias :eql? :==

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -247,7 +247,6 @@ class HalClient
     end
 
     def ==(other)
-      super
       if href
         href == other.href
       else

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.5.1"
+  VERSION = "3.6.0"
 end

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -112,6 +112,45 @@ HAL
     end
   end
 
+  context "equality and hash" do
+    let(:repr_same_href) { described_class.new(hal_client: a_client,
+                                         parsed_json: MultiJson.load(<<-HAL)) }
+    { "_links": { "self": { "href": "http://example.com/foo" } } }
+    HAL
+
+    let(:repr_diff_href) { described_class.new(hal_client: a_client,
+                                         parsed_json: MultiJson.load(<<-HAL)) }
+    { "_links": { "self": { "href": "http://DIFFERENT" } } }
+    HAL
+    let(:repr_no_href) { described_class.new(hal_client: a_client,
+                                         parsed_json: MultiJson.load(<<-HAL)) }
+    { }
+    HAL
+
+    describe "#==" do
+      specify { expect(repr == repr_same_href).to eq true }
+      specify { expect(repr == repr_diff_href).to eq false }
+      specify { expect(repr == repr_no_href).to   eq false }
+      specify { expect(repr_no_href == repr).to   eq false }
+      specify { expect(repr_no_href == repr_no_href).to eq true }
+    end
+
+    describe ".eql?" do
+      specify { expect(repr.eql? repr_same_href).to eq true }
+      specify { expect(repr.eql? repr_diff_href).to eq false }
+      specify { expect(repr.eql? repr_no_href).to   eq false }
+      specify { expect(repr_no_href.eql? repr).to   eq false }
+      specify { expect(repr_no_href.eql? repr_no_href).to eq true }
+    end
+
+    describe "hash" do
+      specify{ expect(repr.hash).to eq repr.href.hash }
+      specify{ expect(repr_no_href.hash).to eq repr_no_href.raw.hash }
+    end
+  end
+
+
+
   specify { expect(repr.property "prop1").to eq 1 }
   specify { expect{repr.property "nonexistent-prop"}.to raise_exception KeyError }
 

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -133,6 +133,7 @@ HAL
       specify { expect(repr == repr_no_href).to   eq false }
       specify { expect(repr_no_href == repr).to   eq false }
       specify { expect(repr_no_href == repr_no_href).to eq true }
+      specify { expect(repr == Object.new).to eq false }
     end
 
     describe ".eql?" do
@@ -141,6 +142,7 @@ HAL
       specify { expect(repr.eql? repr_no_href).to   eq false }
       specify { expect(repr_no_href.eql? repr).to   eq false }
       specify { expect(repr_no_href.eql? repr_no_href).to eq true }
+      specify { expect(repr.eql? Object.new).to eq false }
     end
 
     describe "hash" do


### PR DESCRIPTION
== and .eql? first compare on .href, and fall back to the full parsed json
hash delegates to href.hash, and falls back to the parsed json's hash