### PR TITLE
Add properties method to Representation class

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ The first step in using a HAL based API is getting a representation of one of it
     blog = HalClient.get("http://blog.me/")
     # => #<Representation: http://blog.me/>
 
-`HalClient::Representation`s expose a `#property` method to retrieve properties from the HAL document.
+`HalClient::Representation`s expose a `#property` method to retrieve a single property from the HAL document.
 
     blog.property('title')
     #=> "Some Person's Blog"
+
+They also expose a `#properties` method to retrieve all the properties from the document, as a `Hash`.
+
+    blog.properties
+    #=> {"title"=>"Some Person's Blog", "description"=>"Some description"}
 
 ### Link navigation
 

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -11,6 +11,10 @@ class HalClient
   class Representation
     extend Forwardable
 
+    # Collection of reserved properties
+    # https://tools.ietf.org/html/draft-kelly-json-hal-07#section-4.1
+    RESERVED_PROPERTIES = ['_links', '_embedded'].freeze
+
     # Create a new Representation
     #
     # options - name parameters
@@ -88,6 +92,13 @@ class HalClient
       default_proc ||= ->(_){ default} if default != MISSING
 
       raw.fetch(name.to_s, &default_proc)
+    end
+
+    # Returns a Hash including the key-value pairs of all the properties
+    #   in the resource. It does not include HAL's reserved
+    #   properties (`_links` and `_embedded`).
+    def properties
+      raw.reject { |k, _| RESERVED_PROPERTIES.include? k }
     end
 
     # Returns the URL of the resource this representation represents.

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.10.1"
+  VERSION = "3.11.0"
 end

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -5,6 +5,7 @@ require "hal_client/representation"
 describe HalClient::Representation do
   let(:raw_repr) { <<-HAL }
 { "prop1": 1
+  ,"prop2": 2
   ,"_links": {
     "self": { "href": "http://example.com/foo" }
     ,"link1": { "href": "http://example.com/bar" }
@@ -161,6 +162,9 @@ HAL
   specify { expect(repr.property? "nonexistent-prop").to be false }
   specify { expect(repr.has_property? "nonexistent-prop").to be false }
 
+  specify { expect(repr.properties).to include("prop1" => 1, "prop2" => 2) }
+  specify { expect(repr.properties).to_not include("_links" => 1,
+                                                   "_embedded" => 2) }
 
   specify { expect(subject.href).to eq "http://example.com/foo" }
 


### PR DESCRIPTION
This method returns a `Hash` including a key-value pair for each property in the HAL document. It does not include HAL's reserved properties (`_links` and `_embedded`).