### PR TITLE
Support Hashes convertible to JSON on post, put and patch requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ HalClient supports PUT/POST/PATCH requests to remote resources via it's `#put`, 
     blog.patch(diffs_of_article_as_hal_json_str)
     #=> #<Representation: http://blog.me>
 
-The first argument to `#put`, `#post` and `#patch` may be a `String` or any object that responds to `#to_hal`. Additional options may be passed to change the content type of the post, etc.
+The first argument to `#put`, `#post` and `#patch` may be a `String`, a `Hash` or any object that responds to `#to_hal`. Additional options may be passed to change the content type of the post, etc.
 
 ### PUT requests
 

--- a/lib/hal_client.rb
+++ b/lib/hal_client.rb
@@ -86,6 +86,8 @@ class HalClient
 
         req_body = if data.respond_to? :to_hal
                      data.to_hal
+                   elsif data.is_a? Hash
+                     data.to_json
                    else
                      data
                    end
@@ -101,24 +103,24 @@ class HalClient
     end
   end
 
-  # Post a `Representation` or `String` to the resource identified at `url`.
+  # Post a `Representation`, `String` or `Hash` to the resource identified at `url`.
   #
   # url - The URL of the resource of interest.
-  # data - a `String` or an object that responds to `#to_hal`
+  # data - a `String`, a `Hash` or an object that responds to `#to_hal`
   # headers - custom header fields to use for this request
   def_unsafe_request :post
 
-  # Put a `Representation` or `String` to the resource identified at `url`.
+  # Put a `Representation`, `String` or `Hash` to the resource identified at `url`.
   #
   # url - The URL of the resource of interest.
-  # data - a `String` or an object that responds to `#to_hal`
+  # data - a `String`, a `Hash` or an object that responds to `#to_hal`
   # headers - custom header fields to use for this request
   def_unsafe_request :put
 
-  # Patch a `Representation` or `String` to the resource identified at `url`.
+  # Patch a `Representation`, `String` or `Hash` to the resource identified at `url`.
   #
   # url - The URL of the resource of interest.
-  # data - a `String` or an object that responds to `#to_hal`
+  # data - a `String`, a `Hash` or an object that responds to `#to_hal`
   # headers - custom header fields to use for this request
   def_unsafe_request :patch
 

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.11.1"
+  VERSION = "3.12.0"
 end

--- a/spec/hal_client_spec.rb
+++ b/spec/hal_client_spec.rb
@@ -220,6 +220,19 @@ describe HalClient do
         expect(return_val.code.to_s).to match(/^2../)
       end
     end
+
+    context "body as a Hash" do
+      before do return_val end
+      let(:post_data) { {example: "foo"} }
+
+      let(:post_request) { stub_request(:post, "http://example.com/foo").
+        with(:body => post_data.to_json).
+        to_return body: "{}" }
+
+      it "properly parses the request body" do
+        expect(post_request).to have_been_made
+      end
+    end
   end
 
   describe ".post(<url>)" do


### PR DESCRIPTION
The initial idea was to simply fallback to an object that responds to
`#to_json`, but the `#to_json` extensions implemented in Ruby's JSON
module do not always produce the intended JSON. Examples:

```
"{\"foo\": \"bar\"}".to_json
=> "\"{\\\"foo\\\": \\\"bar\\\"}\""

nil.to_json
=> "null"
```

For this reason, I've decided to only call the method on `Hash objects`.