### PR TITLE
Add link class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-.idea/
-.byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea/
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An easy to use client interface for REST APIs that use [HAL](http://stateless.co
 Usage
 -----
 
-The first step in using a HAL based API is getting a representation of one of its entry point. The simplest way to do this is using the `get` class method of `HalClient`.
+The first step in using a HAL based API is getting a representation of one of its entry points. The simplest way to do this is using the `get` class method of `HalClient`.
 
     blog = HalClient.get("http://blog.me/")
     # => #<Representation: http://blog.me/>
@@ -39,7 +39,7 @@ In the example above `item` is the link rel. The `#related` method extracts embe
 
 #### Request evaluation order
 
-If the `author` relationship was a regular link (that is, not embedded) in the above example the HTTP GET to retrieve Bob's representation from the server does not happen until the `#property` method is called. This lazy dereferencing allows for working with efficiently with larger relationship sets.
+If the `author` relationship was a regular link (that is, not embedded) in the above example the HTTP GET to retrieve Bob's representation from the server does not happen until the `#property` method is called. This lazy dereferencing allows for working more efficiently with larger relationship sets.
 
 #### CURIEs
 

--- a/lib/hal_client.rb
+++ b/lib/hal_client.rb
@@ -7,6 +7,7 @@ class HalClient
   autoload :Representation, 'hal_client/representation'
   autoload :RepresentationSet, 'hal_client/representation_set'
   autoload :CurieResolver, 'hal_client/curie_resolver'
+  autoload :Link, 'hal_client/link'
   autoload :LinksSection, 'hal_client/links_section'
   autoload :Collection, 'hal_client/collection'
   autoload :InvalidRepresentationError, 'hal_client/errors'

--- a/lib/hal_client.rb
+++ b/lib/hal_client.rb
@@ -176,7 +176,7 @@ class HalClient
       begin
         Representation.new(hal_client: self, parsed_json: MultiJson.load(resp.to_s),
                            href: location)
-      rescue MultiJson::ParseError, InvalidRepresentationError, SyntaxError => e
+      rescue MultiJson::ParseError, InvalidRepresentationError => e
         if location
           # response doesn't have a HAL body but we know what resource
           # was created so we can be helpful.

--- a/lib/hal_client.rb
+++ b/lib/hal_client.rb
@@ -176,7 +176,7 @@ class HalClient
       begin
         Representation.new(hal_client: self, parsed_json: MultiJson.load(resp.to_s),
                            href: location)
-      rescue MultiJson::ParseError, InvalidRepresentationError => e
+      rescue MultiJson::ParseError, InvalidRepresentationError, SyntaxError => e
         if location
           # response doesn't have a HAL body but we know what resource
           # was created so we can be helpful.

--- a/lib/hal_client/curie_resolver.rb
+++ b/lib/hal_client/curie_resolver.rb
@@ -2,8 +2,7 @@ require 'addressable/template'
 
 class HalClient
 
-  # Expands CURIEs to fully qualified URLs using a set curie
-  # definitions.
+  # Expands CURIEs to fully qualified URLs using a set of curie definitions.
   class CurieResolver
 
     # Initialize new CurieResolver

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -48,8 +48,8 @@ class HalClient
     end
 
     def ==(other)
-      if (href && other.respond_to?(:href)) && (rel && other.respond_to?(:rel))
-        href == other.href && rel == other.rel
+      if other.respond_to?(:href) && other.respond_to?(:rel)  && other.respond_to?(:templated?)
+        (href == other.href) && (rel == other.rel)  && (templated? == other.templated?)
       else
         false
       end
@@ -58,7 +58,7 @@ class HalClient
 
 
     def hash
-      [rel, href].hash
+      [rel, href, templated?].hash
     end
 
   end

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -92,7 +92,7 @@ class HalClient
       templated? ? template.pattern : target.href
     end
 
-    def resolved_rel
+    def fully_qualified_rel
       curie_resolver.resolve(rel)
     end
 
@@ -105,10 +105,10 @@ class HalClient
     # Otherwise, they are considered unequal
     def ==(other)
       if other.respond_to?(:raw_href) &&
-         other.respond_to?(:resolved_rel) &&
+         other.respond_to?(:fully_qualified_rel) &&
          other.respond_to?(:templated?)
         (raw_href == other.raw_href) &&
-          (resolved_rel == other.resolved_rel) &&
+          (fully_qualified_rel == other.fully_qualified_rel) &&
           (templated? == other.templated?)
       else
         false
@@ -120,7 +120,7 @@ class HalClient
     # Differing Representations or Addressable::Templates with matching hrefs will get matching hash
     # values, since we are using raw_href and not the objects themselves when computing hash
     def hash
-      [resolved_rel, raw_href, templated?].hash
+      [fully_qualified_rel, raw_href, templated?].hash
     end
 
   end

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -38,23 +38,29 @@ class HalClient
 
     attr_accessor :rel, :target, :template, :curie_resolver
 
-    def self.new_from_link_entry(hash_entry:, hal_client:)
+    def self.new_from_link_entry(hash_entry:, hal_client:, curie_resolver:)
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
       href = hash_data['href']
 
       if hash_data['templated']
-        Link.new(rel: rel, template: Addressable::Template.new(href))
+        Link.new(rel: rel,
+                 template: Addressable::Template.new(href),
+                 curie_resolver: curie_resolver)
       else
-        Link.new(rel: rel, target: Representation.new(hal_client: hal_client, href: href))
+        Link.new(rel: rel,
+                 target: Representation.new(hal_client: hal_client, href: href),
+                 curie_resolver: curie_resolver)
       end
     end
 
-    def self.new_from_embedded_entry(hash_entry:, hal_client:)
+    def self.new_from_embedded_entry(hash_entry:, hal_client:, curie_resolver:)
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
 
-      Link.new(rel: rel, target: Representation.new(hal_client: hal_client, parsed_json: hash_data))
+      Link.new(rel: rel,
+               target: Representation.new(hal_client: hal_client, parsed_json: hash_data),
+               curie_resolver: curie_resolver)
     end
 
 

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -1,0 +1,46 @@
+require 'hal_client/representation'
+
+require 'byebug'
+
+class HalClient
+
+  # HAL representation of a single link. Provides access to an embedded representation.
+  class Link
+
+    # Create a new Link
+    #
+    # options - name parameters
+    #   :rel - This Link's rel property
+    #   :target - An instance of Representation
+    def initialize(options)
+      @rel = options[:rel]
+      @target = options[:target]
+
+      (fail ArgumentError, "A rel must be provided") if @rel.nil?
+
+      (fail ArgumentError, "A target must be provided") if @target.nil?
+
+      (fail InvalidRepresentationError, "Invalid HAL representation: #{target.inspect}") unless
+         @target.kind_of?(Representation)
+    end
+
+    attr_accessor :rel, :target
+
+
+    def ==(other)
+      if (target && other.respond_to?(:target)) &&
+        (rel && other.respond_to?(:rel))
+        target == other.target && rel == other.rel
+      else
+        false
+      end
+    end
+    alias :eql? :==
+
+
+    def hash
+      [rel, target].hash
+    end
+
+  end
+end

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -38,10 +38,10 @@ class HalClient
 
     attr_accessor :rel, :target, :template, :curie_resolver
 
-    def self.new_from_link_entry(hash_entry:, hal_client:, curie_resolver:)
+    def self.new_from_link_entry(hash_entry:, hal_client:, curie_resolver:, base_url:)
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
-      href = hash_data['href']
+      href = (Addressable::URI.parse(base_url) + hash_data['href']).to_s
 
       if hash_data['templated']
         Link.new(rel: rel,
@@ -54,9 +54,12 @@ class HalClient
       end
     end
 
-    def self.new_from_embedded_entry(hash_entry:, hal_client:, curie_resolver:)
+    def self.new_from_embedded_entry(hash_entry:, hal_client:, curie_resolver:, base_url:)
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
+
+      absolute_href = (Addressable::URI.parse(base_url) + hash_data['_links']['self']['href']).to_s
+      hash_data['_links']['self']['href'] = absolute_href
 
       Link.new(rel: rel,
                target: Representation.new(hal_client: hal_client, parsed_json: hash_data),

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -37,6 +37,26 @@ class HalClient
 
     attr_accessor :rel, :target, :template
 
+    def self.new_from_link_entry(hash_entry:, hal_client:)
+      rel = hash_entry[:rel]
+      hash_data = hash_entry[:data]
+      href = hash_data['href']
+
+      if hash_data['templated']
+        Link.new(rel: rel, template: Addressable::Template.new(href))
+      else
+        Link.new(rel: rel, target: Representation.new(hal_client: hal_client, href: href))
+      end
+    end
+
+    def self.new_from_embedded_entry(hash_entry:, hal_client:)
+      rel = hash_entry[:rel]
+      hash_data = hash_entry[:data]
+
+      Link.new(rel: rel, target: Representation.new(hal_client: hal_client, parsed_json: hash_data))
+    end
+
+
     # Returns the URL of the resource this link references.
     # In the case of a templated link, this is the unresolved url template pattern.
     def raw_href

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -37,14 +37,19 @@ class HalClient
 
     attr_accessor :rel, :target, :template
 
+    # Returns the URL of the resource this link references.
+    # In the case of a templated link, this is the unresolved url template pattern.
     def raw_href
       templated? ? template.pattern : target.href
     end
 
+    # Returns true for a templated link, false for an ordinary (non-templated) link
     def templated?
       !template.nil?
     end
 
+    # Links with the same href, same rel value, and the same 'templated' value are considered equal
+    # Otherwise, they are considered unequal
     def ==(other)
       if other.respond_to?(:raw_href) && other.respond_to?(:rel)  && other.respond_to?(:templated?)
         (raw_href == other.raw_href) && (rel == other.rel)  && (templated? == other.templated?)
@@ -55,6 +60,8 @@ class HalClient
     alias :eql? :==
 
 
+    # Differing Representations or Addressable::Templates with matching hrefs will get matching hash
+    # values, since we are using raw_href and not the objects themselves when computing hash
     def hash
       [rel, raw_href, templated?].hash
     end

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -56,7 +56,7 @@ class HalClient
 
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
-      href = (Addressable::URI.parse(base_url) + hash_data['href']).to_s
+      href = (base_url + hash_data['href']).to_s
 
       if hash_data['templated']
         Link.new(rel: rel,
@@ -87,7 +87,7 @@ class HalClient
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
 
-      absolute_href = (Addressable::URI.parse(base_url) + hash_data['_links']['self']['href']).to_s
+      absolute_href = (base_url + hash_data['_links']['self']['href']).to_s
       hash_data['_links']['self']['href'] = absolute_href
 
       Link.new(rel: rel,

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -10,7 +10,8 @@ class HalClient
     # options - name parameters
     #   :rel - This Link's rel property
     #   :target - An instance of Representation
-    #   :template = A URI template ( https://www.rfc-editor.org/rfc/rfc6570.txt )
+    #   :template - A URI template ( https://www.rfc-editor.org/rfc/rfc6570.txt )
+    #   :curie_resolver - An instance of CurieResolver (used to resolve curied rels)
     def initialize(options)
       @rel = options[:rel]
       @target = options[:target]
@@ -38,6 +39,15 @@ class HalClient
 
     attr_accessor :rel, :target, :template, :curie_resolver
 
+
+    # Create a new Link using an entry from the '_links' section of a HAL document
+    #
+    # options - name parameters
+    #   :hash_entry - a hash containing keys :rel (string) and :data (hash from a '_links' entry)
+    #   :hal_client - an instance of HalClient
+    #   :curie_resolver - An instance of CurieResolver (used to resolve curied rels)
+    #   :base_url - Base url for resolving relative links in hash_entry (probably the parent
+    # document's "self" link)
     def self.new_from_link_entry(hash_entry:, hal_client:, curie_resolver:, base_url:)
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
@@ -54,6 +64,15 @@ class HalClient
       end
     end
 
+
+    # Create a new Link using an entry from the '_embedded' section of a HAL document
+    #
+    # options - name parameters
+    #   :hash_entry - a hash containing keys :rel (string) and :data (hash from a '_embedded' entry)
+    #   :hal_client - an instance of HalClient
+    #   :curie_resolver - An instance of CurieResolver (used to resolve curied rels)
+    #   :base_url - Base url for resolving relative links in hash_entry (probably the parent
+    # document's "self" link)
     def self.new_from_embedded_entry(hash_entry:, hal_client:, curie_resolver:, base_url:)
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -48,7 +48,12 @@ class HalClient
     #   :curie_resolver - An instance of CurieResolver (used to resolve curied rels)
     #   :base_url - Base url for resolving relative links in hash_entry (probably the parent
     # document's "self" link)
-    def self.new_from_link_entry(hash_entry:, hal_client:, curie_resolver:, base_url:)
+    def self.new_from_link_entry(options)
+      hash_entry = options[:hash_entry]
+      hal_client = options[:hal_client]
+      curie_resolver = options[:curie_resolver]
+      base_url = options[:base_url]
+
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
       href = (Addressable::URI.parse(base_url) + hash_data['href']).to_s
@@ -73,7 +78,12 @@ class HalClient
     #   :curie_resolver - An instance of CurieResolver (used to resolve curied rels)
     #   :base_url - Base url for resolving relative links in hash_entry (probably the parent
     # document's "self" link)
-    def self.new_from_embedded_entry(hash_entry:, hal_client:, curie_resolver:, base_url:)
+    def self.new_from_embedded_entry(options)
+      hash_entry = options[:hash_entry]
+      hal_client = options[:hal_client]
+      curie_resolver = options[:curie_resolver]
+      base_url = options[:base_url]
+
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
 

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -27,11 +27,11 @@ class HalClient
       end
 
       if @target && !@target.kind_of?(Representation)
-        fail InvalidRepresentationError, "Invalid HAL representation: #{target.inspect}"
+        (fail ArgumentError, "Invalid HAL representation: #{target.inspect}")
       end
 
       if @template && !@template.kind_of?(Addressable::Template)
-        fail InvalidRepresentationError, "Invalid Addressable::Template: #{template.inspect}"
+        (fail ArgumentError, "Invalid Addressable::Template: #{template.inspect}")
       end
     end
 

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -37,7 +37,7 @@ class HalClient
 
     attr_accessor :rel, :target, :template
 
-    def href
+    def raw_href
       templated? ? template.pattern : target.href
     end
 
@@ -46,8 +46,8 @@ class HalClient
     end
 
     def ==(other)
-      if other.respond_to?(:href) && other.respond_to?(:rel)  && other.respond_to?(:templated?)
-        (href == other.href) && (rel == other.rel)  && (templated? == other.templated?)
+      if other.respond_to?(:raw_href) && other.respond_to?(:rel)  && other.respond_to?(:templated?)
+        (raw_href == other.raw_href) && (rel == other.rel)  && (templated? == other.templated?)
       else
         false
       end
@@ -56,7 +56,7 @@ class HalClient
 
 
     def hash
-      [rel, href, templated?].hash
+      [rel, raw_href, templated?].hash
     end
 
   end

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -13,12 +13,12 @@ class HalClient
     #   :template - A URI template ( https://www.rfc-editor.org/rfc/rfc6570.txt )
     #   :curie_resolver - An instance of CurieResolver (used to resolve curied rels)
     def initialize(options)
-      @rel = options[:rel]
+      @literal_rel = options[:rel]
       @target = options[:target]
       @template = options[:template]
       @curie_resolver = options[:curie_resolver] || CurieResolver.new([])
 
-      (fail ArgumentError, "A rel must be provided") if @rel.nil?
+      (fail ArgumentError, "A rel must be provided") if @literal_rel.nil?
 
       if @target.nil? && @template.nil?
         (fail ArgumentError, "A target or template must be provided")
@@ -37,7 +37,7 @@ class HalClient
       end
     end
 
-    attr_accessor :rel, :target, :template, :curie_resolver
+    attr_accessor :literal_rel, :target, :template, :curie_resolver
 
 
     # Create a new Link using an entry from the '_links' section of a HAL document
@@ -93,7 +93,7 @@ class HalClient
     end
 
     def fully_qualified_rel
-      curie_resolver.resolve(rel)
+      curie_resolver.resolve(literal_rel)
     end
 
     # Returns true for a templated link, false for an ordinary (non-templated) link

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -12,25 +12,44 @@ class HalClient
     # options - name parameters
     #   :rel - This Link's rel property
     #   :target - An instance of Representation
+    #   :template = A URI template ( https://www.rfc-editor.org/rfc/rfc6570.txt )
     def initialize(options)
       @rel = options[:rel]
       @target = options[:target]
+      @template = options[:template]
 
       (fail ArgumentError, "A rel must be provided") if @rel.nil?
 
-      (fail ArgumentError, "A target must be provided") if @target.nil?
+      if @target.nil? && @template.nil?
+        (fail ArgumentError, "A target or template must be provided")
+      end
 
-      (fail InvalidRepresentationError, "Invalid HAL representation: #{target.inspect}") unless
-         @target.kind_of?(Representation)
+      if @target && @template
+        (fail ArgumentError, "Cannot provide both a target and a template")
+      end
+
+      if @target && !@target.kind_of?(Representation)
+        fail InvalidRepresentationError, "Invalid HAL representation: #{target.inspect}"
+      end
+
+      if @template && !@template.kind_of?(Addressable::Template)
+        fail InvalidRepresentationError, "Invalid Addressable::Template: #{template.inspect}"
+      end
     end
 
-    attr_accessor :rel, :target
+    attr_accessor :rel, :target, :template
 
+    def href
+      templated? ? template.pattern : target.href
+    end
+
+    def templated?
+      !template.nil?
+    end
 
     def ==(other)
-      if (target && other.respond_to?(:target)) &&
-        (rel && other.respond_to?(:rel))
-        target == other.target && rel == other.rel
+      if (href && other.respond_to?(:href)) && (rel && other.respond_to?(:rel))
+        href == other.href && rel == other.rel
       else
         false
       end
@@ -39,7 +58,7 @@ class HalClient
 
 
     def hash
-      [rel, target].hash
+      [rel, href].hash
     end
 
   end

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -1,7 +1,5 @@
 require 'hal_client/representation'
 
-require 'byebug'
-
 class HalClient
 
   # HAL representation of a single link. Provides access to an embedded representation.

--- a/lib/hal_client/links_section.rb
+++ b/lib/hal_client/links_section.rb
@@ -2,8 +2,6 @@ class HalClient
 
   # Encapsulates a "_links" section.
   class LinksSection
-    UNSET = Object.new
-
     # section - json hash for the links section
     # base_url - base URL with which to resolve relative URLs
     def initialize(section, opts={} )

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -179,13 +179,14 @@ class HalClient
 
     def all_links
       result = Set.new
+      base_url = Addressable::URI.parse(href || "")
 
       embedded_entries = flatten_section(raw.fetch("_embedded", {}))
       result.merge(embedded_entries.map do |entry|
         Link.new_from_embedded_entry(hash_entry: entry,
                                      hal_client: hal_client,
                                      curie_resolver: namespaces,
-                                     base_url: href)
+                                     base_url: base_url)
       end)
 
       link_entries = flatten_section(raw.fetch("_links", {}))
@@ -193,7 +194,7 @@ class HalClient
         Link.new_from_link_entry(hash_entry: entry,
                                  hal_client: hal_client,
                                  curie_resolver: namespaces,
-                                 base_url: href) })
+                                 base_url: base_url) })
 
       result
     end

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -292,7 +292,16 @@ class HalClient
     def raw
       if @raw.nil? && @href
         (fail "unable to make requests due to missing hal client") unless hal_client
-        @raw ||= hal_client.get(@href).raw
+
+        response = hal_client.get(@href)
+
+        unless response.is_a?(Representation)
+          error_message = "Response body wasn't a valid HAL document:\n\n"
+          error_message += response.body
+          raise InvalidRepresentationError.new(error_message)
+        end
+
+        @raw ||= response.raw
       end
 
       @raw

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -316,19 +316,12 @@ class HalClient
     MISSING = Object.new
 
     def flatten_section(section_hash)
-      result = Array.new
-
-      section_hash.each_pair do |rel, rel_data|
-        if rel_data.is_a?(Array)
-          rel_data.each do |single_item|
-            result << { rel: rel, data: single_item }
-          end
-        elsif rel_data.is_a?(Hash)
-          result << { rel: rel, data: rel_data };
-        end
-      end
-
-      result
+      section_hash
+        .each_pair
+        .flat_map { |rel, some_link_info|
+          [some_link_info].flatten
+          .map { |a_link_info| { rel: rel, data: a_link_info } }
+      }
     end
 
     def link_from_link_entry(hash_entry)

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -318,7 +318,7 @@ class HalClient
 
     rescue InvalidRepresentationError => err
       fail InvalidRepresentationError, "/_embedded/#{jpointer_esc(link_rel)} is not a valid representation"
-end
+    end
 
     def linked(link_rel, options, &default_proc)
       default_proc ||= ->(link_rel,_options) {

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -181,10 +181,10 @@ class HalClient
       result = Set.new
 
       embedded_entries = flatten_section(raw.fetch("_embedded", {}))
-      embedded_entries.map { |entry| result.add?(link_from_embedded_entry(entry)) }
+      result.merge(embedded_entries.map { |entry| link_from_embedded_entry(entry) })
 
       link_entries = flatten_section(raw.fetch("_links", {}).reject {|k| k == 'self'})
-      link_entries.map { |entry| result.add?(link_from_link_entry(entry)) }
+      result.merge(link_entries.map { |entry| link_from_link_entry(entry) })
 
       result
     end

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -184,14 +184,16 @@ class HalClient
       result.merge(embedded_entries.map do |entry|
         Link.new_from_embedded_entry(hash_entry: entry,
                                      hal_client: hal_client,
-                                     curie_resolver: namespaces)
+                                     curie_resolver: namespaces,
+                                     base_url: href)
       end)
 
       link_entries = flatten_section(raw.fetch("_links", {}).reject {|k| k == 'self'})
       result.merge(link_entries.map { |entry|
         Link.new_from_link_entry(hash_entry: entry,
                                  hal_client: hal_client,
-                                 curie_resolver: namespaces) })
+                                 curie_resolver: namespaces,
+                                 base_url: href) })
 
       result
     end

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -182,12 +182,16 @@ class HalClient
 
       embedded_entries = flatten_section(raw.fetch("_embedded", {}))
       result.merge(embedded_entries.map do |entry|
-        Link.new_from_embedded_entry(hash_entry: entry, hal_client: hal_client)
+        Link.new_from_embedded_entry(hash_entry: entry,
+                                     hal_client: hal_client,
+                                     curie_resolver: namespaces)
       end)
 
       link_entries = flatten_section(raw.fetch("_links", {}).reject {|k| k == 'self'})
       result.merge(link_entries.map { |entry|
-        Link.new_from_link_entry(hash_entry: entry, hal_client: hal_client) })
+        Link.new_from_link_entry(hash_entry: entry,
+                                 hal_client: hal_client,
+                                 curie_resolver: namespaces) })
 
       result
     end

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -323,13 +323,22 @@ class HalClient
     end
 
     def link_from_link_entry(hash_entry)
-      repr = Representation.new(hal_client: hal_client, href: hash_entry[:data]['href'])
-      Link.new(rel: hash_entry[:rel], target: repr)
+      rel = hash_entry[:rel]
+      hash_data = hash_entry[:data]
+      href = hash_data['href']
+
+      if hash_data['templated']
+        Link.new(rel: rel, template: Addressable::Template.new(href))
+      else
+        Link.new(rel: rel, target: Representation.new(hal_client: hal_client, href: href))
+      end
     end
 
     def link_from_embedded_entry(hash_entry)
-      repr = Representation.new(hal_client: hal_client, parsed_json: hash_entry[:data])
-      Link.new(rel: hash_entry[:rel], target: repr)
+      rel = hash_entry[:rel]
+      hash_data = hash_entry[:data]
+
+      Link.new(rel: rel, target: Representation.new(hal_client: hal_client, parsed_json: hash_data))
     end
 
     def links

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -188,7 +188,7 @@ class HalClient
                                      base_url: href)
       end)
 
-      link_entries = flatten_section(raw.fetch("_links", {}).reject {|k| k == 'self'})
+      link_entries = flatten_section(raw.fetch("_links", {}))
       result.merge(link_entries.map { |entry|
         Link.new_from_link_entry(hash_entry: entry,
                                  hal_client: hal_client,

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -99,6 +99,11 @@ describe HalClient::Link do
                           template: Addressable::Template.new('http://example.com/places{?name}'))
     end
 
+    let(:template_but_not_a_template) do
+      HalClient::Link.new(rel: 'rel_1',
+                          template: Addressable::Template.new('http://example.com/href_1'))
+    end
+
     describe "#==" do
       specify { expect(link == link_same_target_same_rel).to eq true }
       specify { expect(link == link_same_non_fetched).to eq true }
@@ -109,6 +114,8 @@ describe HalClient::Link do
 
       specify { expect(templated_link1 == same_as_templated_link1).to eq true }
       specify { expect(templated_link1 == templated_link2).to eq false }
+
+      specify { expect(link == template_but_not_a_template).to eq false }
 
       specify { expect(link == Object.new).to eq false }
     end
@@ -121,8 +128,10 @@ describe HalClient::Link do
       specify { expect(link.eql? link_diff_target_same_rel).to eq false }
       specify { expect(link.eql? link_diff_target_diff_rel).to eq false }
 
-      specify { expect(templated_link1 == same_as_templated_link1).to eq true }
-      specify { expect(templated_link1 == templated_link2).to eq false }
+      specify { expect(templated_link1.eql? same_as_templated_link1).to eq true }
+      specify { expect(templated_link1.eql? templated_link2).to eq false }
+
+      specify { expect(link.eql? template_but_not_a_template).to eq false }
 
       specify { expect(link.eql? Object.new).to eq false }
     end
@@ -137,6 +146,8 @@ describe HalClient::Link do
 
       specify { expect(templated_link1.hash).to eq(same_as_templated_link1.hash) }
       specify { expect(templated_link1.hash).to_not eq(templated_link2.hash) }
+
+      specify { expect(link.hash).to_not eq(template_but_not_a_template.hash)}
     end
 
   end

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -68,6 +68,31 @@ describe HalClient::Link do
   let(:template_1) { Addressable::Template.new('http://example.com/people{?name}') }
 
   let(:templated_link1) { HalClient::Link.new(rel: 'templated_link', template: template_1) }
+
+  describe "#initialize" do
+    # Require target
+    specify { expect { HalClient::Link.new(rel: rel_1) }.to raise_error(ArgumentError) }
+
+    # Don't allow both target and template
+    specify do
+      expect {
+        HalClient::Link.new(rel: rel_1, target: repr_1, template: template_1)
+      }.to raise_error(ArgumentError)
+    end
+
+    # Require target to be a Representation
+    specify do
+      expect {
+        HalClient::Link.new(rel: rel_1, target: template_1)
+      }.to raise_error(ArgumentError)
+    end
+
+    # Require template to be an Addressable::Template
+    specify do
+      expect {
+        HalClient::Link.new(rel: rel_1, template: repr_1)
+      }.to raise_error(ArgumentError)
+    end
   end
 
   describe "#href" do

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -37,7 +37,11 @@ describe HalClient::Link do
 
   let(:relative_href_1) { 'path/to/href_1' }
 
-  def link_entry_hash(href: href_1, rel: rel_1, templated: nil)
+  def link_entry_hash(options = {})
+    href = options[:href] || href_1
+    rel = options[:rel] || rel_1
+    templated = options[:templated] || nil
+
     hash_data = { 'href' => href }
     hash_data['templated'] = templated if templated
 
@@ -47,14 +51,19 @@ describe HalClient::Link do
     }
   end
 
-  def embedded_entry_hash(href: href_1, rel: rel_1)
+  def embedded_entry_hash(options = {})
+    href = options[:href] || href_1
+    rel = options[:rel] || rel_1
+
     {
       rel: rel,
       data: { '_links' => { 'self' => { 'href' => href } } }
     }
   end
 
-  def raw_repr(href: href_1)
+  def raw_repr(options = {})
+    href = options[:href] || href_1
+
     <<-HAL
       {
          "prop1": 1
@@ -76,7 +85,9 @@ describe HalClient::Link do
     HAL
   end
 
-  def href_only_raw_repr(href: href_1)
+  def href_only_raw_repr(options = {})
+    href = options[:href] || href_1
+
     <<-HAL
       {
         "_links": {
@@ -86,7 +97,9 @@ describe HalClient::Link do
     HAL
   end
 
-  def href_only_repr(href: href_1)
+  def href_only_repr(options = {})
+    href = options[:href] || href_1
+
     HalClient::Representation.new(hal_client: a_client,
                                   parsed_json: MultiJson.load(href_only_raw_repr(href: href)))
   end

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -15,6 +15,23 @@ describe HalClient::Link do
   let(:rel_1) { 'rel_1' }
   let(:rel_2) { 'rel_2' }
 
+  let(:full_uri_rel_1) { 'http://example.com/rels/rel_1' }
+  let(:full_uri_link_1) { HalClient::Link.new(rel: full_uri_rel_1, target: repr_1) }
+
+  let(:curie_resolver) do
+    HalClient::CurieResolver.new({
+      'name' => 'ex',
+      'href' => 'http://example.com/rels/{rel}',
+      'templated' => true
+    })
+  end
+
+  let(:curied_rel_1) { 'ex:rel_1' }
+
+  let(:curied_link_1) do
+    HalClient::Link.new(rel: curied_rel_1, target: repr_1, curie_resolver: curie_resolver)
+  end
+
   let(:href_1) { 'http://example.com/href_1' }
   let(:href_2) { 'http://example.com/href_2' }
 
@@ -142,6 +159,8 @@ describe HalClient::Link do
 
       specify { expect(link == template_but_not_a_template).to eq false }
 
+      specify { expect(full_uri_link_1 == curied_link_1).to eq true }
+
       specify { expect(link == Object.new).to eq false }
     end
 
@@ -158,6 +177,8 @@ describe HalClient::Link do
 
       specify { expect(link.eql? template_but_not_a_template).to eq false }
 
+      specify { expect(full_uri_link_1.eql? curied_link_1).to eq true }
+
       specify { expect(link.eql? Object.new).to eq false }
     end
 
@@ -173,6 +194,8 @@ describe HalClient::Link do
       specify { expect(templated_link1.hash).to_not eq(templated_link2.hash) }
 
       specify { expect(link.hash).to_not eq(template_but_not_a_template.hash)}
+
+      specify { expect(full_uri_link_1.hash).to eq(curied_link_1.hash) }
     end
 
   end

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -65,6 +65,21 @@ describe HalClient::Link do
                                   parsed_json: MultiJson.load(raw_repr2))
   end
 
+  let(:templated_link1) do
+    HalClient::Link.new(rel: 'templated_link',
+                        template: Addressable::Template.new('http://example.com/people{?name}'))
+  end
+
+  describe "#href" do
+    specify { expect(link.href).to eq('http://example.com/href_1') }
+    specify { expect(templated_link1.href).to eq('http://example.com/people{?name}') }
+  end
+
+  describe "#templated?" do
+    specify { expect(link.templated?).to be false }
+    specify { expect(templated_link1.templated?).to be true }
+  end
+
   context "equality and hash" do
     let(:link_same_target_same_rel) { HalClient::Link.new(target: repr_1, rel: rel_1) }
 
@@ -74,6 +89,16 @@ describe HalClient::Link do
 
     let(:link_same_non_fetched) { HalClient::Link.new(target: repr_1_non_fetched, rel: rel_1) }
 
+    let(:same_as_templated_link1) do
+      HalClient::Link.new(rel: 'templated_link',
+                          template: Addressable::Template.new('http://example.com/people{?name}'))
+    end
+
+    let(:templated_link2) do
+      HalClient::Link.new(rel: 'templated_link',
+                          template: Addressable::Template.new('http://example.com/places{?name}'))
+    end
+
     describe "#==" do
       specify { expect(link == link_same_target_same_rel).to eq true }
       specify { expect(link == link_same_non_fetched).to eq true }
@@ -81,6 +106,9 @@ describe HalClient::Link do
       specify { expect(link == link_same_target_diff_rel).to eq false }
       specify { expect(link == link_diff_target_same_rel).to eq false }
       specify { expect(link == link_diff_target_diff_rel).to eq false }
+
+      specify { expect(templated_link1 == same_as_templated_link1).to eq true }
+      specify { expect(templated_link1 == templated_link2).to eq false }
 
       specify { expect(link == Object.new).to eq false }
     end
@@ -93,6 +121,9 @@ describe HalClient::Link do
       specify { expect(link.eql? link_diff_target_same_rel).to eq false }
       specify { expect(link.eql? link_diff_target_diff_rel).to eq false }
 
+      specify { expect(templated_link1 == same_as_templated_link1).to eq true }
+      specify { expect(templated_link1 == templated_link2).to eq false }
+
       specify { expect(link.eql? Object.new).to eq false }
     end
 
@@ -103,6 +134,9 @@ describe HalClient::Link do
       specify{ expect(link.hash).to_not eq link_same_target_diff_rel.hash }
       specify{ expect(link.hash).to_not eq link_diff_target_same_rel.hash }
       specify{ expect(link.hash).to_not eq link_diff_target_diff_rel.hash }
+
+      specify { expect(templated_link1.hash).to eq(same_as_templated_link1.hash) }
+      specify { expect(templated_link1.hash).to_not eq(templated_link2.hash) }
     end
 
   end

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -1,0 +1,111 @@
+require 'hal-client'
+
+require_relative "../spec_helper"
+
+require "hal_client/link"
+
+describe HalClient::Link do
+
+  subject(:link) { described_class.new(rel: rel_1, target: repr_1) }
+
+  # Background
+
+  let(:a_client) { HalClient.new }
+
+  let(:rel_1) { 'rel_1' }
+  let(:rel_2) { 'rel_2' }
+
+  let(:href_1) { 'http://example.com/href_1' }
+  let(:href_2) { 'http://example.com/href_2' }
+
+  def raw_repr(href: href_1)
+    <<-HAL
+      {
+         "prop1": 1
+        ,"prop2": 2
+        ,"_links": {
+          "self": { "href": "#{href}" }
+          ,"link1": { "href": "http://example.com/bar" }
+          ,"templated_link": { "href": "http://example.com/people{?name}"
+                      ,"templated": true }
+          ,"link3": [{ "href": "http://example.com/link3-a" }
+                     ,{ "href": "http://example.com/link3-b" }]
+        }
+        ,"_embedded": {
+          "embed1": {
+            "_links": { "self": { "href": "http://example.com/baz" }}
+          }
+        }
+      }
+    HAL
+  end
+
+  def raw_repr2(href: href_1)
+    <<-HAL
+      {
+        "_links": {
+          "self": { "href": "#{href}" }
+        }
+      }
+    HAL
+  end
+
+  let(:repr_1) do
+    HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(raw_repr))
+  end
+
+  let(:repr_2) do
+     HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(raw_repr(href: href_2)))
+  end
+
+  let(:repr_1_non_fetched) do
+    HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(raw_repr2))
+  end
+
+  context "equality and hash" do
+    let(:link_same_target_same_rel) { HalClient::Link.new(target: repr_1, rel: rel_1) }
+
+    let(:link_same_target_diff_rel) { HalClient::Link.new(target: repr_1, rel: rel_2) }
+    let(:link_diff_target_same_rel) { HalClient::Link.new(target: repr_2, rel: rel_1) }
+    let(:link_diff_target_diff_rel) { HalClient::Link.new(target: repr_2, rel: rel_2) }
+
+    let(:link_same_non_fetched) { HalClient::Link.new(target: repr_1_non_fetched, rel: rel_1) }
+
+    describe "#==" do
+      specify { expect(link == link_same_target_same_rel).to eq true }
+      specify { expect(link == link_same_non_fetched).to eq true }
+
+      specify { expect(link == link_same_target_diff_rel).to eq false }
+      specify { expect(link == link_diff_target_same_rel).to eq false }
+      specify { expect(link == link_diff_target_diff_rel).to eq false }
+
+      specify { expect(link == Object.new).to eq false }
+    end
+
+    describe ".eql?" do
+      specify { expect(link.eql? link_same_target_same_rel).to eq true }
+      specify { expect(link.eql? link_same_non_fetched).to eq true }
+
+      specify { expect(link.eql? link_same_target_diff_rel).to eq false }
+      specify { expect(link.eql? link_diff_target_same_rel).to eq false }
+      specify { expect(link.eql? link_diff_target_diff_rel).to eq false }
+
+      specify { expect(link.eql? Object.new).to eq false }
+    end
+
+    describe "hash" do
+      specify{ expect(link.hash).to eq link_same_target_same_rel.hash }
+      specify{ expect(link.hash).to eq link_same_non_fetched.hash }
+
+      specify{ expect(link.hash).to_not eq link_same_target_diff_rel.hash }
+      specify{ expect(link.hash).to_not eq link_diff_target_same_rel.hash }
+      specify{ expect(link.hash).to_not eq link_diff_target_diff_rel.hash }
+    end
+
+  end
+
+
+end

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -87,25 +87,23 @@ describe HalClient::Link do
   let(:templated_link1) { HalClient::Link.new(rel: 'templated_link', template: template_1) }
 
   describe "#initialize" do
-    # Require target
-    specify { expect { HalClient::Link.new(rel: rel_1) }.to raise_error(ArgumentError) }
+    it "requires a target" do
+      expect { HalClient::Link.new(rel: rel_1) }.to raise_error(ArgumentError)
+    end
 
-    # Don't allow both target and template
-    specify do
+    it "doesn't allow both target and template" do
       expect {
         HalClient::Link.new(rel: rel_1, target: repr_1, template: template_1)
       }.to raise_error(ArgumentError)
     end
 
-    # Require target to be a Representation
-    specify do
+    it "requires target to be a Representation" do
       expect {
         HalClient::Link.new(rel: rel_1, target: template_1)
       }.to raise_error(ArgumentError)
     end
 
-    # Require template to be an Addressable::Template
-    specify do
+    it "requires template to be an Addressable::Template" do
       expect {
         HalClient::Link.new(rel: rel_1, template: repr_1)
       }.to raise_error(ArgumentError)

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -57,7 +57,7 @@ describe HalClient::Link do
     HAL
   end
 
-  def raw_repr2(href: href_1)
+  def href_only_raw_repr(href: href_1)
     <<-HAL
       {
         "_links": {
@@ -79,7 +79,7 @@ describe HalClient::Link do
 
   let(:repr_1_non_fetched) do
     HalClient::Representation.new(hal_client: a_client,
-                                  parsed_json: MultiJson.load(raw_repr2))
+                                  parsed_json: MultiJson.load(href_only_raw_repr))
   end
 
   let(:template_1) { Addressable::Template.new('http://example.com/people{?name}') }

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -8,116 +8,6 @@ describe HalClient::Link do
 
   subject(:link) { described_class.new(rel: rel_1, target: repr_1) }
 
-  # Background
-
-  let(:a_client) { HalClient.new }
-
-  let(:rel_1) { 'rel_1' }
-  let(:rel_2) { 'rel_2' }
-
-  let(:full_uri_rel_1) { 'http://example.com/rels/rel_1' }
-  let(:full_uri_link_1) { HalClient::Link.new(rel: full_uri_rel_1, target: repr_1) }
-
-  let(:curie_resolver) do
-    HalClient::CurieResolver.new({
-      'name' => 'ex',
-      'href' => 'http://example.com/rels/{rel}',
-      'templated' => true
-    })
-  end
-
-  let(:curied_rel_1) { 'ex:rel_1' }
-
-  let(:curied_link_1) do
-    HalClient::Link.new(rel: curied_rel_1, target: repr_1, curie_resolver: curie_resolver)
-  end
-
-  let(:href_1) { 'http://example.com/href_1' }
-  let(:href_2) { 'http://example.com/href_2' }
-
-  let(:relative_href_1) { 'path/to/href_1' }
-
-  def link_entry_hash(options = {})
-    href = options[:href] || href_1
-    rel = options[:rel] || rel_1
-    templated = options[:templated] || nil
-
-    hash_data = { 'href' => href }
-    hash_data['templated'] = templated if templated
-
-    {
-      rel: rel,
-      data: hash_data
-    }
-  end
-
-  def embedded_entry_hash(options = {})
-    href = options[:href] || href_1
-    rel = options[:rel] || rel_1
-
-    {
-      rel: rel,
-      data: { '_links' => { 'self' => { 'href' => href } } }
-    }
-  end
-
-  def raw_repr(options = {})
-    href = options[:href] || href_1
-
-    <<-HAL
-      {
-         "prop1": 1
-        ,"prop2": 2
-        ,"_links": {
-          "self": { "href": "#{href}" }
-          ,"link1": { "href": "http://example.com/bar" }
-          ,"templated_link": { "href": "http://example.com/people{?name}"
-                      ,"templated": true }
-          ,"link3": [{ "href": "http://example.com/link3-a" }
-                     ,{ "href": "http://example.com/link3-b" }]
-        }
-        ,"_embedded": {
-          "embed1": {
-            "_links": { "self": { "href": "http://example.com/baz" }}
-          }
-        }
-      }
-    HAL
-  end
-
-  def href_only_raw_repr(options = {})
-    href = options[:href] || href_1
-
-    <<-HAL
-      {
-        "_links": {
-          "self": { "href": "#{href}" }
-        }
-      }
-    HAL
-  end
-
-  def href_only_repr(options = {})
-    href = options[:href] || href_1
-
-    HalClient::Representation.new(hal_client: a_client,
-                                  parsed_json: MultiJson.load(href_only_raw_repr(href: href)))
-  end
-
-  let(:repr_1) do
-    HalClient::Representation.new(hal_client: a_client,
-                                  parsed_json: MultiJson.load(raw_repr))
-  end
-
-  let(:repr_2) do
-     HalClient::Representation.new(hal_client: a_client,
-                                  parsed_json: MultiJson.load(raw_repr(href: href_2)))
-  end
-
-  let(:template_1) { Addressable::Template.new('http://example.com/people{?name}') }
-
-  let(:templated_link1) { HalClient::Link.new(rel: 'templated_link', template: template_1) }
-
   describe "#initialize" do
     it "requires a target" do
       expect { HalClient::Link.new(rel: rel_1) }.to raise_error(ArgumentError)
@@ -268,5 +158,115 @@ describe HalClient::Link do
 
   end
 
+
+  # Background
+
+  let(:a_client) { HalClient.new }
+
+  let(:rel_1) { 'rel_1' }
+  let(:rel_2) { 'rel_2' }
+
+  let(:full_uri_rel_1) { 'http://example.com/rels/rel_1' }
+  let(:full_uri_link_1) { HalClient::Link.new(rel: full_uri_rel_1, target: repr_1) }
+
+  let(:curie_resolver) do
+    HalClient::CurieResolver.new({
+                                   'name' => 'ex',
+                                   'href' => 'http://example.com/rels/{rel}',
+                                   'templated' => true
+                                 })
+  end
+
+  let(:curied_rel_1) { 'ex:rel_1' }
+
+  let(:curied_link_1) do
+    HalClient::Link.new(rel: curied_rel_1, target: repr_1, curie_resolver: curie_resolver)
+  end
+
+  let(:href_1) { 'http://example.com/href_1' }
+  let(:href_2) { 'http://example.com/href_2' }
+
+  let(:relative_href_1) { 'path/to/href_1' }
+
+  def link_entry_hash(options = {})
+    href = options[:href] || href_1
+    rel = options[:rel] || rel_1
+    templated = options[:templated] || nil
+
+    hash_data = { 'href' => href }
+    hash_data['templated'] = templated if templated
+
+    {
+      rel: rel,
+      data: hash_data
+    }
+  end
+
+  def embedded_entry_hash(options = {})
+    href = options[:href] || href_1
+    rel = options[:rel] || rel_1
+
+    {
+      rel: rel,
+      data: { '_links' => { 'self' => { 'href' => href } } }
+    }
+  end
+
+  def raw_repr(options = {})
+    href = options[:href] || href_1
+
+    <<-HAL
+      {
+         "prop1": 1
+        ,"prop2": 2
+        ,"_links": {
+          "self": { "href": "#{href}" }
+          ,"link1": { "href": "http://example.com/bar" }
+          ,"templated_link": { "href": "http://example.com/people{?name}"
+                      ,"templated": true }
+          ,"link3": [{ "href": "http://example.com/link3-a" }
+                     ,{ "href": "http://example.com/link3-b" }]
+        }
+        ,"_embedded": {
+          "embed1": {
+            "_links": { "self": { "href": "http://example.com/baz" }}
+          }
+        }
+      }
+    HAL
+  end
+
+  def href_only_raw_repr(options = {})
+    href = options[:href] || href_1
+
+    <<-HAL
+      {
+        "_links": {
+          "self": { "href": "#{href}" }
+        }
+      }
+    HAL
+  end
+
+  def href_only_repr(options = {})
+    href = options[:href] || href_1
+
+    HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(href_only_raw_repr(href: href)))
+  end
+
+  let(:repr_1) do
+    HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(raw_repr))
+  end
+
+  let(:repr_2) do
+    HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(raw_repr(href: href_2)))
+  end
+
+  let(:template_1) { Addressable::Template.new('http://example.com/people{?name}') }
+
+  let(:templated_link1) { HalClient::Link.new(rel: 'templated_link', template: template_1) }
 
 end

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -43,11 +43,13 @@ describe HalClient::Link do
 
     it "handles relative hrefs" do
       input_hash = link_entry_hash(href: relative_href_1)
+      base_url = Addressable::URI.parse(href_1)
+
       my_link = described_class.new_from_link_entry(hash_entry: input_hash,
                                                     hal_client: a_client,
                                                     curie_resolver: curie_resolver,
-                                                    base_url: href_1)
-      expect(my_link.raw_href).to eq((Addressable::URI.parse(href_1) + relative_href_1).to_s)
+                                                    base_url: base_url)
+      expect(my_link.raw_href).to eq((base_url + relative_href_1).to_s)
     end
   end
 
@@ -62,11 +64,13 @@ describe HalClient::Link do
 
     it "handles relative hrefs" do
       input_hash = embedded_entry_hash(href: relative_href_1)
+      base_url = Addressable::URI.parse(href_1)
+
       my_link = described_class.new_from_embedded_entry(hash_entry: input_hash,
                                                         hal_client: a_client,
                                                         curie_resolver: curie_resolver,
-                                                        base_url: href_1)
-      expect(my_link.raw_href).to eq((Addressable::URI.parse(href_1) + relative_href_1).to_s)
+                                                        base_url: base_url)
+      expect(my_link.raw_href).to eq((base_url + relative_href_1).to_s)
     end
   end
 

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -71,8 +71,8 @@ describe HalClient::Link do
   end
 
   describe "#href" do
-    specify { expect(link.href).to eq('http://example.com/href_1') }
-    specify { expect(templated_link1.href).to eq('http://example.com/people{?name}') }
+    specify { expect(link.raw_href).to eq('http://example.com/href_1') }
+    specify { expect(templated_link1.raw_href).to eq('http://example.com/people{?name}') }
   end
 
   describe "#templated?" do

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -65,9 +65,9 @@ describe HalClient::Link do
                                   parsed_json: MultiJson.load(raw_repr2))
   end
 
-  let(:templated_link1) do
-    HalClient::Link.new(rel: 'templated_link',
-                        template: Addressable::Template.new('http://example.com/people{?name}'))
+  let(:template_1) { Addressable::Template.new('http://example.com/people{?name}') }
+
+  let(:templated_link1) { HalClient::Link.new(rel: 'templated_link', template: template_1) }
   end
 
   describe "#href" do

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -67,6 +67,11 @@ describe HalClient::Link do
     HAL
   end
 
+  def href_only_repr(href: href_1)
+    HalClient::Representation.new(hal_client: a_client,
+                                  parsed_json: MultiJson.load(href_only_raw_repr(href: href)))
+  end
+
   let(:repr_1) do
     HalClient::Representation.new(hal_client: a_client,
                                   parsed_json: MultiJson.load(raw_repr))
@@ -75,11 +80,6 @@ describe HalClient::Link do
   let(:repr_2) do
      HalClient::Representation.new(hal_client: a_client,
                                   parsed_json: MultiJson.load(raw_repr(href: href_2)))
-  end
-
-  let(:repr_1_non_fetched) do
-    HalClient::Representation.new(hal_client: a_client,
-                                  parsed_json: MultiJson.load(href_only_raw_repr))
   end
 
   let(:template_1) { Addressable::Template.new('http://example.com/people{?name}') }
@@ -129,7 +129,7 @@ describe HalClient::Link do
     let(:link_diff_target_same_rel) { HalClient::Link.new(target: repr_2, rel: rel_1) }
     let(:link_diff_target_diff_rel) { HalClient::Link.new(target: repr_2, rel: rel_2) }
 
-    let(:link_same_non_fetched) { HalClient::Link.new(target: repr_1_non_fetched, rel: rel_1) }
+    let(:link_same_non_fetched) { HalClient::Link.new(target: href_only_repr, rel: rel_1) }
 
     let(:same_as_templated_link1) do
       HalClient::Link.new(rel: 'templated_link',

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -13,10 +13,15 @@ describe HalClient::Representation do
                 ,"templated": true }
     ,"link3": [{ "href": "http://example.com/link3-a" }
                ,{ "href": "http://example.com/link3-b" }]
+    ,"dup": { "href": "http://example.com/dup" }
   }
   ,"_embedded": {
     "embed1": {
       "_links": { "self": { "href": "http://example.com/baz" }}
+    }
+    ,"dup": {
+      "dupProperty": "foo"
+      ,"_links": { "self": { "href": "http://example.com/dup" }}
     }
   }
 }
@@ -264,6 +269,20 @@ HAL
     end
   end
 
+  describe "#all_links" do
+    subject { repr.all_links }
+
+    specify { expect(subject).to include(link1_link) }
+    specify { expect(subject).to_not include(link2_link) }
+
+    specify { expect(subject).to include(templated_link_link) }
+
+    specify { expect(subject).to include(link3a_link) }
+    specify { expect(subject).to include(link3b_link) }
+
+    specify { expect(subject.any? { |item| item.target['dupProperty'] == 'foo' }).to be true }
+  end
+
   specify { expect(repr.related_hrefs "link1")
       .to contain_exactly "http://example.com/bar" }
   specify { expect(repr.related_hrefs "embed1")
@@ -395,6 +414,44 @@ HAL
   end
 
   # Background
+
+  let(:link1_repr) do
+    HalClient::Representation.new(hal_client: a_client, href: "http://example.com/bar")
+  end
+
+  let(:templated_link_repr) do
+    HalClient::Representation.new(hal_client: a_client, href: "http://example.com/people{?name}")
+  end
+
+  let(:link3a_repr) do
+    HalClient::Representation.new(hal_client: a_client, href: "http://example.com/link3-a")
+  end
+
+  let(:link3b_repr) do
+    HalClient::Representation.new(hal_client: a_client, href: "http://example.com/link3-b")
+  end
+
+
+  let(:link1_link) do
+    HalClient::Link.new(rel: 'link1', target: link1_repr)
+  end
+
+  let(:link2_link) do
+    HalClient::Link.new(rel: 'link2', target: link1_repr)
+  end
+
+  let(:templated_link_link) do
+    HalClient::Link.new(rel: 'templated_link', target: templated_link_repr)
+  end
+
+  let(:link3a_link) do
+    HalClient::Link.new(rel: 'link3', target: link3a_repr)
+  end
+
+  let(:link3b_link) do
+    HalClient::Link.new(rel: 'link3', target: link3b_repr)
+  end
+
 
   let(:a_client) { HalClient.new }
   let!(:bar_request) { stub_identity_request("http://example.com/bar") }

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -9,7 +9,7 @@ describe HalClient::Representation do
   ,"_links": {
     "self": { "href": "http://example.com/foo" }
     ,"link1": { "href": "http://example.com/bar" }
-    ,"templated_link": { "href": "http://example.com/people{?name}"
+    ,"templated": { "href": "http://example.com/people{?name}"
                 ,"templated": true }
     ,"link3": [{ "href": "http://example.com/link3-a" }
                ,{ "href": "http://example.com/link3-b" }]
@@ -251,7 +251,7 @@ HAL
     end
 
     context "for existent templated link" do
-      subject { repr.related "templated_link", name: "bob" }
+      subject { repr.related "templated", name: "bob" }
       it { should have(1).item }
       it { should include_representation_of "http://example.com/people?name=bob"  }
     end
@@ -275,7 +275,7 @@ HAL
     specify { expect(subject).to include(link1_link) }
     specify { expect(subject).to_not include(link2_link) }
 
-    specify { expect(subject).to include(templated_link_link) }
+    specify { expect(subject).to include(templated_link) }
 
     specify { expect(subject).to include(link3a_link) }
     specify { expect(subject).to include(link3b_link) }
@@ -289,7 +289,7 @@ HAL
       .to contain_exactly "http://example.com/baz" }
   specify { expect { repr.related_hrefs 'wat' }.to raise_exception KeyError }
 
-  specify { expect(repr.raw_related_hrefs("templated_link").map(&:pattern))
+  specify { expect(repr.raw_related_hrefs("templated").map(&:pattern))
       .to contain_exactly "http://example.com/people{?name}" }
   specify { expect(repr.raw_related_hrefs("link1"))
       .to contain_exactly "http://example.com/bar" }
@@ -419,10 +419,6 @@ HAL
     HalClient::Representation.new(hal_client: a_client, href: "http://example.com/bar")
   end
 
-  let(:templated_link_repr) do
-    HalClient::Representation.new(hal_client: a_client, href: "http://example.com/people{?name}")
-  end
-
   let(:link3a_repr) do
     HalClient::Representation.new(hal_client: a_client, href: "http://example.com/link3-a")
   end
@@ -440,8 +436,9 @@ HAL
     HalClient::Link.new(rel: 'link2', target: link1_repr)
   end
 
-  let(:templated_link_link) do
-    HalClient::Link.new(rel: 'templated_link', target: templated_link_repr)
+  let(:templated_link) do
+    HalClient::Link.new(rel: 'templated',
+                        template: Addressable::Template.new('http://example.com/people{?name}'))
   end
 
   let(:link3a_link) do


### PR DESCRIPTION
Adding 'Link' class and an 'all_links' method in Representation.

all_links will return a collection of Link objects representing entries in both the '_links' and 'embedded' sections of the given Representation.