### PR TITLE
Simplify Representation#related? method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ rvm:
   - "2.1.0"
   - "2.2.0"
   - rbx-2.7
-  
+
+matrix:
+  allow_failures:
+  - rvm: rbx-2.7

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -159,7 +159,7 @@ class HalClient
     #
     # link_rel - The link rel of interest
     def related?(link_rel)
-      !!(linked(link_rel, {}) { false } || embedded(link_rel) { false })
+      !!(linked(link_rel) { false } || embedded(link_rel) { false })
     end
     alias_method :has_related?, :related?
 
@@ -363,7 +363,7 @@ class HalClient
       fail InvalidRepresentationError, "/_embedded/#{jpointer_esc(link_rel)} is not a valid representation"
     end
 
-    def linked(link_rel, options, &default_proc)
+    def linked(link_rel, options = {}, &default_proc)
       default_proc ||= NO_LINK_FOUND
 
       relations = links.hrefs(link_rel) { MISSING }

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -159,7 +159,7 @@ class HalClient
     #
     # link_rel - The link rel of interest
     def related?(link_rel)
-      !!(linked(link_rel, {}) { nil } || embedded(link_rel) { nil })
+      !!(linked(link_rel, {}) { false } || embedded(link_rel) { false })
     end
     alias_method :has_related?, :related?
 

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -159,11 +159,7 @@ class HalClient
     #
     # link_rel - The link rel of interest
     def related?(link_rel)
-      _ = related link_rel
-      true
-
-    rescue KeyError
-      false
+      !!(linked(link_rel, {}) { nil } || embedded(link_rel) { nil })
     end
     alias_method :has_related?, :related?
 

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.16.1"
+  VERSION = "3.16.2"
 end


### PR DESCRIPTION
This method relied on `#related` to work, which was rather heavy:
* when no related was found, an exception was raised and caught, just so we could return `false`
* when a related was found, a new representation was created, which was discarded so we could return `true`

Since `RepresentationSet` calls `#has_related?` --- which is an alias for `#related?` --- quite often, we can inline a simpler version of `#related?` to avoid the overhead described above.

This PR also bumps the `hal-client` version to `3.16.2`.