### PR TITLE
Reuse connections for requests with same headers

### DIFF
--- a/hal-client.gemspec
+++ b/hal-client.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "webmock", ["~> 1.17", ">= 1.17.4"]
   spec.add_development_dependency "rspec-collection_matchers"
+  spec.add_development_dependency "pry"
 end

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.16.2"
+  VERSION = "3.17.0"
 end


### PR DESCRIPTION
The #client_for_get and #client_for_post methods attempted to reuse
HTTP::Client instances whenever no override headers were received (when
they were nil).

Unfortunately, both always received as override headers the result of
 #auth_headers, which is always at least at empty hash.

This meant that HTTP::Client instances were never actually reused, and
instead a new one was created on every request, even if the gem users
never actually specified custom headers for requests.

Furthermore, even if the above scheme did not have a bug, we would still
always create a new HTTP::Client instance for every request with custom
headers, which is rather inefficient.

This commit fixes both of the above issues by caching HTTP::Client
instances keyed by request headers. Thus, requests with no overridden
headers will always reuse the same instance, and requests with custom
headers will reuse instances whenever the custom headers are the same.

This is especially useful when combined with http persistent
connections.

Fixes #56