### PR TITLE
Support latest http gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
-sudo: false
-cache: bundler
 language: ruby
-rvm:
-  - "2.0.0"
-  - "2.1.0"
-  - "2.2.0"
-  - rbx-2.7
 
-matrix:
-  allow_failures:
-  - rvm: rbx-2.7
+dist: trusty
+sudo: false
+
+before_install:
+  - rvm get head
+  - gem install bundler
+
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2.6
+  - 2.3.2
+  - jruby-9.1.6.0
+  - rbx-2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ rvm:
   - 2.3.2
   - jruby-9.1.6.0
   - rbx-2.7
+
+gemfile:
+  - Gemfile
+  - Gemfile-http-0.8
+  - Gemfile-http-0.9
+  - Gemfile-http-1.0

--- a/Gemfile-http-0.8
+++ b/Gemfile-http-0.8
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in hal-client.gemspec
+gemspec
+
+gem 'http', '~> 0.8.4'

--- a/Gemfile-http-0.9
+++ b/Gemfile-http-0.9
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in hal-client.gemspec
+gemspec
+
+gem 'http', '~> 0.9'

--- a/Gemfile-http-1.0
+++ b/Gemfile-http-1.0
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in hal-client.gemspec
+gemspec
+
+gem 'http', '~> 1.0'

--- a/hal-client.gemspec
+++ b/hal-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "http", "~> 0.7"
+  spec.add_dependency "http", ">= 0.8.4", "< 3.0"
   spec.add_dependency "addressable", "~> 2.3"
   spec.add_dependency "multi_json", "~> 1.9"
 

--- a/lib/hal_client.rb
+++ b/lib/hal_client.rb
@@ -240,7 +240,7 @@ class HalClient
   def base_client_with_headers(headers)
     @base_client_with_headers[headers.to_h] ||= begin
       logger.debug { "Created base_client with headers #{headers.inspect}" }
-      base_client.with_headers(headers)
+      base_client.headers(headers)
     end
   end
 

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.17.1"
+  VERSION = "3.18.0"
 end

--- a/spec/hal_client_spec.rb
+++ b/spec/hal_client_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe HalClient do
       subject(:client) { HalClient.new(base_client: base_client) }
 
       it 'creates a base client with headers' do
-        expect(base_client).to receive(:with_headers) do |headers|
+        expect(base_client).to receive(:headers) do |headers|
           expect(headers.to_h).to include('Accept' => 'application/hal+json;q=0')
 
           real_client
@@ -104,7 +104,7 @@ RSpec.describe HalClient do
       end
 
       it 'reuses base client with headers instances' do
-        expect(base_client).to receive(:with_headers) do |headers|
+        expect(base_client).to receive(:headers) do |headers|
           expect(headers.to_h).to include('Accept' => 'application/hal+json;q=0', 'Foo' => 'Bar')
 
           real_client
@@ -112,7 +112,7 @@ RSpec.describe HalClient do
 
         client.get("http://example.com/foo", 'Foo' => 'Bar')
 
-        expect(base_client).to receive(:with_headers) do |headers|
+        expect(base_client).to receive(:headers) do |headers|
           expect(headers.to_h).to include('Accept' => 'application/hal+json;q=0', 'Hello' => 'World')
 
           real_client
@@ -324,7 +324,7 @@ RSpec.describe HalClient do
       subject(:client) { HalClient.new(base_client: base_client) }
 
       it 'creates a base client with headers' do
-        expect(base_client).to receive(:with_headers) do |headers|
+        expect(base_client).to receive(:headers) do |headers|
           expect(headers.to_h).to include('Accept' => 'application/hal+json;q=0')
 
           real_client
@@ -334,7 +334,7 @@ RSpec.describe HalClient do
       end
 
       it 'reuses base client with headers instances' do
-        expect(base_client).to receive(:with_headers) do |headers|
+        expect(base_client).to receive(:headers) do |headers|
           expect(headers.to_h).to include('Accept' => 'application/hal+json;q=0', 'Foo' => 'Bar')
 
           real_client
@@ -342,7 +342,7 @@ RSpec.describe HalClient do
 
         client.post(url, post_data, 'Foo' => 'Bar')
 
-        expect(base_client).to receive(:with_headers) do |headers|
+        expect(base_client).to receive(:headers) do |headers|
           expect(headers.to_h).to include('Accept' => 'application/hal+json;q=0', 'Hello' => 'World')
 
           real_client


### PR DESCRIPTION
This patch is based off of previous work by @jeromegn and @tjsousa (thanks for pointing the way!).

The only change needed to hal_client is to stop using the Client#with_headers method, and instead make use of Client#headers.

The #headers method was introduced for release 0.8.4 in httprb/http@a5d2266 and thus it can be safely used even in < 1.0 gem versions.

Earlier PRs: pezra/hal-client#49 jeromegn/hal-client#1

I have tested this branch with http gem versions 0.8.4, 0.9.9, 1.0.4 and 2.1.0 with both hal-client's specs and several internal @Talkdesk applications (took me a while to go through the whole matrix) successfully.