### PR TITLE
Fixed bug where hal-client could not handle hrefs with a nil value

### DIFF
--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -56,6 +56,7 @@ class HalClient
 
       rel = hash_entry[:rel]
       hash_data = hash_entry[:data]
+      return nil unless hash_data['href']
       href = (base_url + hash_data['href']).to_s
 
       if hash_data['templated']

--- a/lib/hal_client/links_section.rb
+++ b/lib/hal_client/links_section.rb
@@ -50,6 +50,7 @@ class HalClient
     def resolve_to_url(link)
       (fail HalClient::InvalidRepresentationError) unless link.respond_to? :fetch
 
+      return nil unless link.fetch("href")
       url = base_url + link.fetch("href")
       is_templated = link.fetch("templated", false)
 

--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -367,7 +367,7 @@ class HalClient
       default_proc ||= NO_LINK_FOUND
 
       relations = links.hrefs(link_rel) { MISSING }
-      return default_proc.call(link_rel, options) if relations == MISSING
+      return default_proc.call(link_rel, options) if relations == MISSING || relations.compact.empty?
 
       relations
         .map {|url_or_tmpl|

--- a/spec/hal_client/link_spec.rb
+++ b/spec/hal_client/link_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe HalClient::Link do
                                                     base_url: base_url)
       expect(my_link.raw_href).to eq((base_url + relative_href_1).to_s)
     end
+
+    it "handles hrefs with a nil value" do
+      input_hash = link_entry_hash(href: nil)
+      base_url = Addressable::URI.parse(href_1)
+
+      my_link = described_class.new_from_link_entry(hash_entry: input_hash,
+                                                    hal_client: a_client,
+                                                    curie_resolver: curie_resolver,
+                                                    base_url: base_url)
+
+      expect(my_link.raw_href).to eq(base_url.to_s)
+    end
   end
 
   describe ".new_from_embedded_entry" do

--- a/spec/hal_client/links_section_spec.rb
+++ b/spec/hal_client/links_section_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe HalClient::LinksSection, "namespaces embedded" do
 
   specify { expect{section.hrefs("nonexistent")}.to raise_error KeyError }
 
+  specify { expect(section.hrefs("nil_href"))
+    .to contain_exactly nil }
+
   let(:fully_qualified_first_rel) { "http://rels.example.com/first" }
   let(:fully_qualified_second_rel) { "http://rels.example.com/2/second" }
 
@@ -45,6 +48,7 @@ RSpec.describe HalClient::LinksSection, "namespaces embedded" do
       "ns1:first" => {"href" => "http://example.com/foo"},
       "ns2:second" => [{"href" => "http://example.com/bar"},
                        {"href" => "http://example.com/baz"}],
+      "nil_href" => {"href" => nil},
       "next" => {"href" =>  "/foo?p=2"}
     } }
 

--- a/spec/hal_client/representation_spec.rb
+++ b/spec/hal_client/representation_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe HalClient::Representation do
                 ,"templated": true }
     ,"link3": [{ "href": "http://example.com/link3-a" }
                ,{ "href": "http://example.com/link3-b" }]
+    ,"nil_link": { "href": null }
     ,"dup": { "href": "http://example.com/dup" }
   }
   ,"_embedded": {
@@ -301,6 +302,7 @@ HAL
 
   specify { expect(subject.has_related? "no-such-link-or-embed").to be false }
   specify { expect(subject.related? "no-such-link-or-embed").to be false }
+  specify { expect(subject.related? "nil_link").to be false }
 
   specify { expect(subject.to_json).to be_equivalent_json_to raw_repr }
   specify { expect(subject.to_hal).to be_equivalent_json_to raw_repr }


### PR DESCRIPTION
When an href is null is throws a conversion error when it tries to add the base url.