### PR TITLE
Prevent Representation clone failures due to a missing hal-client

### DIFF
--- a/lib/hal_client/representation.rb
+++ b/lib/hal_client/representation.rb
@@ -51,7 +51,9 @@ class HalClient
     # environments
     def clone_for_use_in_different_thread
       clone.tap do |c|
-        c.hal_client = c.hal_client.clone_for_use_in_different_thread
+        if c.hal_client
+          c.hal_client = c.hal_client.clone_for_use_in_different_thread
+        end
       end
     end
 


### PR DESCRIPTION
A Representation doesn't necessarily have a hal-client instance.  Don't attempt to clone hal-client if one isn't set.