### PR TITLE
form fields with multi-level paths work

### DIFF
--- a/hal-client.gemspec
+++ b/hal-client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.1"
-  spec.add_development_dependency "rspec", "~> 3.5"
+  spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "webmock", ["~> 1.17", ">= 1.17.4"]
   spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "pry"

--- a/lib/hal_client/form.rb
+++ b/lib/hal_client/form.rb
@@ -98,11 +98,19 @@ class HalClient
     end
 
     def json_inject_answer(body, answer, path)
-      patch = Hana::Patch.new [
-        { 'op' => 'add', 'path' => path, 'value' => answer }
-      ]
+      ptr = Hana::Pointer.new(path).entries
 
-      patch.apply(body)
+      target_container = if ptr.count == 1
+                           body
+                         else
+                           ptr[0..-2].inject(body) { |ctx, segment|
+                             ctx.fetch(segment) { ctx[segment] = {} }
+                           }
+                         end
+
+      target_container[ptr.last] = answer
+
+      body
     end
   end
 end

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "6.0.0"
+  VERSION = "6.0.1"
 end

--- a/spec/hal_client/form_spec.rb
+++ b/spec/hal_client/form_spec.rb
@@ -56,6 +56,20 @@ RSpec.describe HalClient::Form do
       }
     end
 
+    context "POST form w/ nested field path and json content type" do
+      subject { HalClient::Form.new(post_form_with_nested_field_path_and_json_content_type, a_client) }
+
+      specify {
+        expect{
+          subject.submit(rating: "ok", description: "pretty good")
+        }.to make_http_request(
+               stub_request(:post, subject.target_url)
+               .with(body: { container: {rating: "ok", description: "pretty good"} },
+                     headers: { "Content-Type" => "application/json" })
+             )
+      }
+    end
+
   end
 
   # Background
@@ -103,6 +117,25 @@ RSpec.describe HalClient::Form do
         { "name" => "description",
           "type" => "text",
           "path" => "/description" }
+      ]
+    }
+  end
+
+  def post_form_with_nested_field_path_and_json_content_type
+    { "_links" => {
+        "target" => {
+          "href" => "http://example.com/"
+        }
+      },
+      "method" => "POST",
+      "contentType" => "application/json",
+      "fields" => [
+        { "name" => "rating",
+          "type" => "number",
+          "path" => "/container/rating" },
+        { "name" => "description",
+          "type" => "text",
+          "path" => "/container/description" }
       ]
     }
   end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,5 +1,6 @@
 module CustomMatchers
   extend RSpec::Matchers::DSL
+
   matcher :behave_like_a do |expected_class|
     match do |actual_instance|
       (expected_methods(expected_class) - actual_instance.methods).empty?


### PR DESCRIPTION
previously a form field like the follow would make a form unsubmittable.

        {
          "value": "-3",
          "validations": {
            "required": true,
            "regex": null
          },
          "type": "number",
          "path": "/change/value",
          "name": "rate",
          "displayTest": "Set-point-delta rate (W)"
        },
