### PR TITLE
Add support for Ruby 3

### DIFF
--- a/hal-client.gemspec
+++ b/hal-client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{An easy to use interface for REST APIs that use HAL.}
   spec.homepage      = "https://github.com/pezra/hal-client"
   spec.license       = "MIT"
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/hal_client/link.rb
+++ b/lib/hal_client/link.rb
@@ -8,7 +8,7 @@ class HalClient
       @literal_rel = rel
       @curie_resolver = curie_resolver
 
-      post_initialize(opts)
+      post_initialize(**opts)
     end
 
     def raw_href

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "6.0.1"
+  VERSION = "6.0.2"
 end


### PR DESCRIPTION
This PR adds a double splat operator usage on the `post_initialize` method call. This is needed in Ruby 3 version, due to the usage of hashes on named parameters. More on that [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

Let me know if there's anything else I can do or change 👍 